### PR TITLE
Re-add envtest and move common setup

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,0 +1,56 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"os"
+	"testing"
+
+	releaseapiextensions "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	kcp "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
+)
+
+// TestMain is the entry point to all tests, it ensures some common setup is
+// done before testing and invokes the actual tests via `M.Run()`.
+func TestMain(m *testing.M) {
+	testEnvSetup()
+	os.Exit(m.Run())
+}
+
+func testEnvSetup() {
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+	ctrl.SetLogger(klogr.New())
+	klog.Info("testEnvSetup")
+	utilruntime.Must(capi.AddToScheme(scheme.Scheme))
+	utilruntime.Must(capiexp.AddToScheme(scheme.Scheme))
+	utilruntime.Must(releaseapiextensions.AddToScheme(scheme.Scheme))
+	utilruntime.Must(capz.AddToScheme(scheme.Scheme))
+	utilruntime.Must(capzexp.AddToScheme(scheme.Scheme))
+	utilruntime.Must(kcp.AddToScheme(scheme.Scheme))
+}

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/giantswarm/apiextensions v0.4.20
 	github.com/go-logr/logr v0.1.0
+	github.com/onsi/ginkgo v1.14.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.17.14
 	k8s.io/apimachinery v0.17.14
 	k8s.io/apiserver v0.17.14
 	k8s.io/client-go v0.17.14
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/cluster-api v0.3.14
 	sigs.k8s.io/cluster-api-provider-azure v0.4.12
 	sigs.k8s.io/controller-runtime v0.5.14


### PR DESCRIPTION
This adds envtest-based integration test environment that allows writing
integration tests with API server available and moves test environment
setup common to both unit and integration tests into a single place.

The current setup just ensures all necessary kinds are registered with
the k8s scheme.