### PR TITLE
Use architect-orb 2.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.4.1
 
 version: 2.1
 workflows:


### PR DESCRIPTION
It contains kubebuilder binaries necessary for integration tests in the image.