### PR TITLE
Use architect-orb 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.7.0
 
 version: 2.1
 workflows:

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -451,18 +451,19 @@ func (r *ClusterReconciler) upgradeMachinePools(ctx context.Context, cluster *ca
 		return false, err
 	}
 
-	for _, machinePool := range clusterMachinePools {
+	for idx := range clusterMachinePools {
+		machinePool := &clusterMachinePools[idx]
 		logger := r.Log.WithValues("cluster", cluster.Name, "machinepool", machinePool.Name)
 
 		// If a MachinePool is not ready we exit because we don't want to
 		// trigger an upgrade while something is wrong or another upgrade is in
 		// progress.
-		if !isReady(&machinePool) {
+		if !isReady(machinePool) {
 			logger.Info("The MachinePool is not ready. Let's wait before trying to continue upgrading machine pools")
 			return true, nil
 		}
 
-		nodesWillBeRolled, err := r.upgradeMachinePool(ctx, cluster, &machinePool, giantswarmRelease)
+		nodesWillBeRolled, err := r.upgradeMachinePool(ctx, cluster, machinePool, giantswarmRelease)
 		if err != nil {
 			return false, err
 		}
@@ -487,16 +488,17 @@ func (r *ClusterReconciler) upgradeMachineDeployments(ctx context.Context, clust
 	}
 
 	logger.Info("Looping through the MachineDeployments to see if they need to be upgraded", "numberOfMachineDeployments", len(clusterMachineDeployments))
-	for _, machineDeployment := range clusterMachineDeployments {
+	for idx := range clusterMachineDeployments {
+		machineDeployment := &clusterMachineDeployments[idx]
 		// If a MachineDeployment is not completed we exit because we don't want to
 		// trigger an upgrade while something is wrong or another upgrade is in
 		// progress.
-		if !mdutil.DeploymentComplete(&machineDeployment, &machineDeployment.Status) {
+		if !mdutil.DeploymentComplete(machineDeployment, &machineDeployment.Status) {
 			logger.Info("MachineDeployment is currently being rolled", "machineDeployment", machineDeployment.Name)
 			return true, nil
 		}
 
-		waitBeforeUpgradingNext, err := r.upgradeMachineDeployment(ctx, cluster, &machineDeployment, giantswarmRelease)
+		waitBeforeUpgradingNext, err := r.upgradeMachineDeployment(ctx, cluster, machineDeployment, giantswarmRelease)
 		if err != nil {
 			return false, err
 		}

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // < v0.7.0 has a deprecation on pkg/client/fake that was removed in later versions
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 


### PR DESCRIPTION
This is needed for two reasons:

- 2.7.0 unblock CI pushing to GitHub as it contains fixed auth key
- 2.4.1 contains kubebuilder binaries necessary for integration tests
  in the architect image

Since newer architect also brings in a newer version of `golangci-lint`
which now detects a couple more issues with the code, this also contains
fixes for those issues which makes the linting pass:

- `G601: Implicit memory aliasing in for loop. (gosec)` in couple of
  places in `controllers/cluster_controller.go` (lines 460, 465, 494,
  499)
- `SA1019: package sigs.k8s.io/controller-runtime/pkg/client/fake is
  deprecated` in `controllers/cluster_controller_test.go:26`